### PR TITLE
init fix for velocity + crash fix for velocity bedwars

### DIFF
--- a/games/6872274481.lua
+++ b/games/6872274481.lua
@@ -1,4 +1,5 @@
 local badexecutor = false
+local isVelocity = getgenv and getgenv().getexecutor and getgenv().getexecutor():match("Velocity")
 local isAlive = function(self)
 	assert(self);
 	local suc, res = pcall(function()
@@ -30,9 +31,8 @@ local contextActionService = cloneref(game:GetService('ContextActionService'))
 local coreGui = cloneref(game:GetService('CoreGui'))
 local starterGui = cloneref(game:GetService('StarterGui'))
 
-local isnetworkowner = not inputService.TouchEnabled and isnetworkowner or function()
-	return true
-end
+local fakenetworkowner = function() return true end
+local isnetworkowner = isVelocity and fakenetworkowner or (not inputService.TouchEnabled and isnetworkowner or fakenetworkowner)
 
 local setfflag = setfflag or function(a, b) end;
 

--- a/init.lua
+++ b/init.lua
@@ -87,7 +87,7 @@ end
 
 if not getgenv().catvapedev then 
 	if not isfolder('newcatvape') or #listfiles('newcatvape') <= 6 then
-		for _, folder in {'newcatvape', 'newcatvape/games', 'newcatvape/profiles', 'newcatvape/assets', 'newcatvape/libraries', 'newcatvape/guis'} do
+		for _, folder in {'newcatvape', 'newcatvape/games', 'newcatvape/profiles', 'newcatvape/assets', 'newcatvape/assets/new', 'newcatvape/assets/old', 'newcatvape/assets/rise', 'newcatvape/assets/sigma', 'newcatvape/libraries', 'newcatvape/guis'} do
 			if not isfolder(folder) then
 				makefolder(folder)
 			end


### PR DESCRIPTION
universal also uses isnetworkowner but that should be a fix for another day

btw velocity will still sometimes crash randomly or on execution while using catvape 

xoxo agent